### PR TITLE
feat: assign host to support virtual hosting

### DIFF
--- a/reverseproxy.go
+++ b/reverseproxy.go
@@ -147,6 +147,9 @@ func (p *ReverseProxy) ServeHTTP(ctx *fasthttp.RequestCtx) {
 		ctx.Logger().Printf("recv a requets to proxy to: %s", pc.Addr)
 	}
 
+	// assign the host to support virtual hosting, aka shared web hosting (one IP, multiple domains)
+	req.SetHost(pc.Addr)
+
 	if err := pc.Do(req, res); err != nil {
 		ctx.Logger().Printf("[ERROR] could not proxy: %v\n", err)
 		res.SetStatusCode(http.StatusInternalServerError)


### PR DESCRIPTION
Ref: https://en.wikipedia.org/wiki/Virtual_hosting

When the proxied target machine hosts multiple domains, the proxy will fail and always get the `Bad Request` response.

An example target: https://api-js.mixpanel.com.

The following code is an example that demonstrates the fail situation:

```
var (
	mixpanelProxyServer = proxy.NewReverseProxy("api-js.mixpanel.com")
)

func proxyRequest(ctx *fasthttp.RequestCtx) {
	mixpanelProxyServer.ServeHTTP(ctx)
	fmt.Println("---------req:", ctx.Request.String())
	fmt.Println("=========res:", ctx.Response.String())
}
```

Always get the following response:

```
HTTP/1.1 400 Bad Request
Server: UploadServer
Date: Mon, 22 Jun 2020 04:58:20 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 188
X-Guploader-Uploadid: AAANsUnTFJ7nYOqjw8cQriiIw6lFPAE7C5Cgb9bogPrYsB0PZyahoDybFgwWPY_BAs_9Q_mvKVl68YCdzQxXumeaaY0

<?xml version='1.0' encoding='UTF-8'?><Error><Code>InvalidArgument</Code><Message>Invalid argument.</Message><Details>POST object expects Content-Type multipart/form-data</Details></Error>
```

Until I added the `ctx.URI().SetHost("api-js.mixpanel.com")` (same as `ctx.Request.SetHost("...")`), it works normally.

But adding `ctx.URI().SetHost("api-js.mixpanel.com")` before `mixpanelProxyServer.ServeHTTP(ctx)` outputs the wrong log.

Expected log:

```
2020/06/22 16:09:29 4.950 #0000000100000002 - 127.0.0.1:8090<->127.0.0.1:53589 - POST http://127.0.0.1:8090/track/?verbose=1&ip=1&_=1592813369644 - recv a requets to proxy to: api-js.mixpanel.com
```

Actual log:

```
2020/06/22 14:23:49 5.378 #0000000100000002 - 127.0.0.1:8090<->127.0.0.1:57365 - POST http://api-js.mixpanel.com/track/?verbose=1&ip=1&_=1592807029796 - recv a requets to proxy to: api-js.mixpanel.com
```

If I misunderstand the host, please correct me.