### PR TITLE
Fix forward Cookie header in builtin func

### DIFF
--- a/ws_reverseproxy.go
+++ b/ws_reverseproxy.go
@@ -179,7 +179,7 @@ func builtinForwardHeaderHandler(ctx *fasthttp.RequestCtx) (forwardHeader http.H
 	}
 
 	if cookie := ctx.Request.Header.Peek("Cookie"); string(cookie) != "" {
-		forwardHeader.Add("Sec-WebSocket-Protocol", string(cookie))
+		forwardHeader.Add("Cookie", string(cookie))
 	}
 
 	if string(ctx.Request.Host()) != "" {


### PR DESCRIPTION
This code:
https://github.com/yeqown/fasthttp-reverse-proxy/blob/65c03ce38c8a093382696f1587db057246c0eb14/ws_reverseproxy.go#L181-L183
should be changed to:
```go
if cookie := ctx.Request.Header.Peek("Cookie"); string(cookie) != "" {
	forwardHeader.Add("Cookie", string(cookie))
}
```