### PR TITLE
add disable virtual host

### DIFF
--- a/reverseproxy.go
+++ b/reverseproxy.go
@@ -138,7 +138,9 @@ func (p *ReverseProxy) ServeHTTP(ctx *fasthttp.RequestCtx) {
 	debugF(p.opt.debug, p.opt.logger, "rev request headers to proxy, addr = %s, headers = %s", c.Addr, req.Header.String())
 
 	// assign the host to support virtual hosting, aka shared web hosting (one IP, multiple domains)
-	req.SetHost(c.Addr)
+	if !p.opt.disableVirtualHost {
+		req.SetHost(c.Addr)
+	}
 
 	// execute the request and rev response with timeout
 	if err := p.doWithTimeout(c, req, res); err != nil {

--- a/reverseproxy_option.go
+++ b/reverseproxy_option.go
@@ -37,6 +37,9 @@ type buildOption struct {
 	// disablePathNormalizing disable path normalizing.
 	disablePathNormalizing bool
 
+	// disableVirtualHost disable virtual host.
+	disableVirtualHost bool
+
 	// maxConnDuration of hostClient
 	maxConnDuration time.Duration
 }
@@ -51,6 +54,7 @@ func defaultBuildOption() *buildOption {
 		tlsConfig:              nil,
 		timeout:                0,
 		disablePathNormalizing: false,
+		disableVirtualHost:     false,
 		maxConnDuration:        0,
 	}
 }
@@ -121,6 +125,13 @@ func WithTimeout(d time.Duration) Option {
 func WithDisablePathNormalizing(isDisablePathNormalizing bool) Option {
 	return newFuncBuildOption(func(o *buildOption) {
 		o.disablePathNormalizing = isDisablePathNormalizing
+	})
+}
+
+// WithDisableVirtualHost sets whether disable virtual host.
+func WithDisableVirtualHost(isDisableVirtualHost bool) Option {
+	return newFuncBuildOption(func(o *buildOption) {
+		o.disableVirtualHost = isDisableVirtualHost
 	})
 }
 


### PR DESCRIPTION
In some reverse proxy scenarios, the backend address may not match the host. For example, the backend could be an IP and port combination, while an existing vhost on it still needs to be manually specified. In such cases, it isn’t appropriate to automatically set the HTTP request host to the backend address. Therefore, I added a switch that gives users the option to manually modify the host in `RequestCtx`.