### PR TITLE
add stream response body

### DIFF
--- a/reverseproxy.go
+++ b/reverseproxy.go
@@ -68,6 +68,8 @@ func (p *ReverseProxy) init() error {
 				IsTLS:                  p.opt.tlsConfig != nil,
 				TLSConfig:              p.opt.tlsConfig,
 				DisablePathNormalizing: p.opt.disablePathNormalizing,
+				MaxResponseBodySize:    p.opt.maxResponseBodySize,
+				StreamResponseBody:     p.opt.streamResponseBody,
 			}
 			p.clients = append(p.clients, client)
 		}
@@ -84,6 +86,8 @@ func (p *ReverseProxy) init() error {
 		IsTLS:                  p.opt.tlsConfig != nil,
 		TLSConfig:              p.opt.tlsConfig,
 		DisablePathNormalizing: p.opt.disablePathNormalizing,
+		MaxResponseBodySize:    p.opt.maxResponseBodySize,
+		StreamResponseBody:     p.opt.streamResponseBody,
 		MaxConnDuration:        p.opt.maxConnDuration,
 	}
 	p.clients = append(p.clients, client)

--- a/reverseproxy_option.go
+++ b/reverseproxy_option.go
@@ -40,6 +40,12 @@ type buildOption struct {
 	// disableVirtualHost disable virtual host.
 	disableVirtualHost bool
 
+	// maxResponseBodySize is the maximum response body size in bytes.
+	maxResponseBodySize int
+
+	// streamResponseBody denotes whether stream response body or not.
+	streamResponseBody bool
+
 	// maxConnDuration of hostClient
 	maxConnDuration time.Duration
 }
@@ -132,6 +138,14 @@ func WithDisablePathNormalizing(isDisablePathNormalizing bool) Option {
 func WithDisableVirtualHost(isDisableVirtualHost bool) Option {
 	return newFuncBuildOption(func(o *buildOption) {
 		o.disableVirtualHost = isDisableVirtualHost
+	})
+}
+
+// WithStreamResponseBody sets whether stream response body or not.
+func WithStreamResponseBody(size int) Option {
+	return newFuncBuildOption(func(o *buildOption) {
+		o.streamResponseBody = true
+		o.maxResponseBodySize = size
 	})
 }
 


### PR DESCRIPTION
In scenarios where the reverse proxy needs to handle large files, it can run out of memory and cause an OOM error. To prevent this, it’s necessary to enable the `StreamResponseBody` option in `fasthttp` and use `MaxResponseBodySize` to set the buffer size. Therefore, I have added a `WithStreamResponseBody` method to implement this functionality.

Ref: https://github.com/valyala/fasthttp/issues/1948